### PR TITLE
Error in Horizontal positioning

### DIFF
--- a/jquery.lightbox.js
+++ b/jquery.lightbox.js
@@ -93,7 +93,7 @@
 			if (self.pageYOffset) {
 				yScroll = self.pageYOffset;
 				xScroll = self.pageXOffset;
-			} else if (document.documentElement && document.documentElement.scrollTop){  // Explorer 6 Strict
+			} else if (document.documentElement && (document.documentElement.scrollTop || document.documentElement.scrollLeft)){  // Explorer 6 Strict, Firefox
 				yScroll = document.documentElement.scrollTop;
 				xScroll = document.documentElement.scrollLeft;
 			} else if (document.body) {// all other Explorers


### PR DESCRIPTION
getPageScroll returned (0,0) if page was only scrolled horizontally in Firefox and IE8 leading to positioning the lightbox on the left side of the page even when scrolled. Only occurs if vertical scroll is 0.
