### PR TITLE
Resume compatibility with the latest version 

### DIFF
--- a/jquery.lightbox.js
+++ b/jquery.lightbox.js
@@ -17,7 +17,7 @@
         
 		$(window).resize(resizeOverlayToFitWindow);
         
-		return $(this).live(opts.triggerEvent,function(){
+		return $(this).on(opts.triggerEvent,function(){
 			// initialize the lightbox
 			initialize();
 			showLightbox(this);


### PR DESCRIPTION
Replaced .live() with .on() method according to http://api.jquery.com/on in order to ensure the compatibility with jQuery 1.7+
