### PR TITLE
Optional selector to support dynamic content.

### DIFF
--- a/jquery.lightbox.js
+++ b/jquery.lightbox.js
@@ -17,7 +17,7 @@
         
 		$(window).resize(resizeOverlayToFitWindow);
         
-		return $(this).on(opts.triggerEvent,function(){
+		return $(this).on(opts.triggerEvent, opts.selector, function(){
 			// initialize the lightbox
 			initialize();
 			showLightbox(this);
@@ -503,6 +503,7 @@
 			loopImages: false,
 			imageClickClose: true,
 			jsonData: null,
-			jsonDataParser: null
+			jsonDataParser: null,
+			selector: ''
 		};	
 })(jQuery);


### PR DESCRIPTION
With this change, you can use the lightbox with dynamic content, without having to re-initialize it when the content is added.
Call is similar to `on` event, only the selector is passed in the option object argument.

Use as 

```
$(document).lightbox({selector: 'a.lightbox'});
```

The normal syntax will also still work.
